### PR TITLE
Implement Rudimentary EWallet with MoneyOut and SinglePayMoneyIn

### DIFF
--- a/ACMEClientExtension/ACMEClientExtension.csproj
+++ b/ACMEClientExtension/ACMEClientExtension.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DirectScale.Disco.Extension.Abstractions" Version="1.0.5112" />
+    <PackageReference Include="DirectScale.Disco.Extension.Abstractions" Version="1.0.5162" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.10" />
   </ItemGroup>
 

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
@@ -1,0 +1,82 @@
+﻿using ACMEClientExtension.Merchants.Ewallet.Interfaces;
+using DirectScale.Disco.Extension;
+using DirectScale.Disco.Extension.MoneyIn.Custom.Models;
+using System;
+using ACMEClientExtension.Merchants.Ewallet.Models;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
+using DirectScale.Disco.Extension.Services;
+
+namespace ACMEClientExtension.Merchants.Ewallet
+{
+    public class EWalletMoneyIn : SinglePaymentMoneyInMerchant
+    {
+        public const int MerchantId = 9100; // TODO: REMOVE
+
+        private readonly IEwalletService _ewalletService;
+        private readonly IAssociateService _associateService;
+        public EWalletMoneyIn(IEwalletService ewalletService, IAssociateService associateService)
+        {
+            _ewalletService = ewalletService ?? throw new ArgumentNullException(nameof(ewalletService));
+            _associateService = associateService ?? throw new ArgumentNullException(nameof(associateService));
+        }
+        public async override Task<PaymentResponse> ChargePayment(string payerId, int orderNumber, double amount, Address billingAddress, string currencyCode)
+        {
+            var paymentResponse = new PaymentResponse()
+            {
+                Amount = amount,
+                Currency = currencyCode,
+                ResponseId = Guid.NewGuid().ToString(),
+                Response = Guid.NewGuid().ToString(),
+                TransactionNumber = Guid.NewGuid().ToString(),
+                Status = PaymentStatus.NotProvided,
+                AuthorizationCode = "N/A",
+                Merchant = MerchantId
+            };
+
+            Models.TransactionStatus result = await _ewalletService.RemoveFromBalance(payerId, (decimal)amount);
+
+            if (result == Models.TransactionStatus.Success)
+            {
+                paymentResponse.Status = PaymentStatus.Accepted;
+            }
+            else if (result == Models.TransactionStatus.InsufficientFunds)
+            {
+                paymentResponse.Status = PaymentStatus.Rejected;
+            }
+
+            return await Task.FromResult(paymentResponse);
+        }
+
+        public async override Task<ExtendedPaymentResult> RefundPayment(string payerId, int orderNumber, string currencyCode, double paymentAmount, double refundAmount, string referenceNumber, string transactionNumber, string authorizationCode)
+        {
+            var paymentResult = new ExtendedPaymentResult()
+            {
+                Amount = refundAmount,
+                Currency = currencyCode,
+                ResponseId = Guid.NewGuid().ToString(),
+                Response = Guid.NewGuid().ToString(),
+                TransactionNumber = transactionNumber,
+                Status = PaymentStatus.NotProvided,
+                AuthorizationCode = authorizationCode,
+            };
+
+            Models.TransactionStatus result = await _ewalletService.AddToBalance(payerId, (decimal)refundAmount);
+
+            if (result == Models.TransactionStatus.Success)
+            {
+                paymentResult.Status = PaymentStatus.Accepted;
+            }
+
+            return await Task.FromResult(paymentResult);
+        }
+
+        public async override Task<string> GetNewPayerId(int associateId)
+        {
+            Associate associate = await _associateService.GetAssociate(associateId);
+
+            return await _ewalletService.ProvisionAccount(associateId, associate.DisplayFirstName, associate.DisplayLastName, associate.EmailAddress);
+        }
+    }
+}

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
@@ -12,7 +12,7 @@ namespace ACMEClientExtension.Merchants.Ewallet
 {
     public class EWalletMoneyIn : SinglePaymentMoneyInMerchant
     {
-        public const int MerchantId = 9100; // TODO: REMOVE
+        public const int MerchantId = 9100;
 
         private readonly IEwalletService _ewalletService;
         private readonly IAssociateService _associateService;

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
@@ -12,8 +12,6 @@ namespace ACMEClientExtension.Merchants.Ewallet
 {
     public class EWalletMoneyIn : SinglePaymentMoneyInMerchant
     {
-        public const int MerchantId = 9100;
-
         private readonly IEwalletService _ewalletService;
         private readonly IAssociateService _associateService;
         public EWalletMoneyIn(IEwalletService ewalletService, IAssociateService associateService)
@@ -31,8 +29,7 @@ namespace ACMEClientExtension.Merchants.Ewallet
                 Response = "Not Provided",
                 TransactionNumber = Guid.NewGuid().ToString(),
                 Status = PaymentStatus.NotProvided,
-                AuthorizationCode = "N/A",
-                Merchant = MerchantId
+                AuthorizationCode = "N/A"
             };
 
             Models.TransactionStatus result = await _ewalletService.RemoveFromBalance(payerId, (decimal)amount);

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyIn.cs
@@ -28,7 +28,7 @@ namespace ACMEClientExtension.Merchants.Ewallet
                 Amount = amount,
                 Currency = currencyCode,
                 ResponseId = Guid.NewGuid().ToString(),
-                Response = Guid.NewGuid().ToString(),
+                Response = "Not Provided",
                 TransactionNumber = Guid.NewGuid().ToString(),
                 Status = PaymentStatus.NotProvided,
                 AuthorizationCode = "N/A",
@@ -40,10 +40,12 @@ namespace ACMEClientExtension.Merchants.Ewallet
             if (result == Models.TransactionStatus.Success)
             {
                 paymentResponse.Status = PaymentStatus.Accepted;
+                paymentResponse.Response = "Accepted";
             }
             else if (result == Models.TransactionStatus.InsufficientFunds)
             {
                 paymentResponse.Status = PaymentStatus.Rejected;
+                paymentResponse.Response = "Insufficient Funds";
             }
 
             return await Task.FromResult(paymentResponse);

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyOut.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyOut.cs
@@ -10,17 +10,11 @@ namespace ACMEClientExtension.Merchants.Ewallet
 {
     public class EWalletMoneyOut : CommissionMerchant
     {
-        public const int MerchantId = 9101;
-        private const string _merchantName = "MyCommissionMerchant";
-
-
         public const string AccountNumber = "AccountNumber";
-        public IMoneyOutService _moneyOutService { get; set; }
         public IEwalletService _ewalletService { get; set; }
         private readonly IAssociateService _associateService;
-        public EWalletMoneyOut(IMoneyOutService moneyOutService, IEwalletService ewalletService, IAssociateService associateService)
+        public EWalletMoneyOut(IEwalletService ewalletService, IAssociateService associateService)
         {
-            _moneyOutService = moneyOutService ?? throw new ArgumentNullException(nameof(moneyOutService));
             _ewalletService = ewalletService ?? throw new ArgumentNullException(nameof(ewalletService));
             _associateService = associateService ?? throw new ArgumentNullException(nameof(associateService));
         }
@@ -43,11 +37,11 @@ namespace ACMEClientExtension.Merchants.Ewallet
                 {
                     payAssociateResult = await PayAssociate(payments[i]);
                 }
-                catch (Exception) // do not let external calls stop the loop because some may have processed successfully.
+                catch (Exception e) // do not let external calls stop the loop because some may have processed successfully.
                 {
                     commissionPaymentResults[i].Status = CommissionPaymentStatus.Failed;
                     commissionPaymentResults[i].TransactionNumber = "transaction number from external system if applicable";
-                    commissionPaymentResults[i].ErrorMessage = "Error message from external payment vendor";
+                    commissionPaymentResults[i].ErrorMessage = e.Message;
                 }
 
                 if (payAssociateResult == Models.TransactionStatus.Success)
@@ -64,9 +58,11 @@ namespace ACMEClientExtension.Merchants.Ewallet
         {
             string accountNumber = "";
             bool accountProvisioned = commissionPayment.MerchantCustomFields.TryGetValue(AccountNumber, out accountNumber);
-            if (!accountProvisioned)
+
+            if (!accountProvisioned) // Accounts are automatically provisioned by the DS System prior calling PayCommissions() if ProvisionAccount() is implemented.
             {
-                accountNumber = await ProvisionNewAccount(commissionPayment.AssociateId, commissionPayment.MerchantId, _merchantName);
+                throw new Exception($"No Account is created for AssociateID: {commissionPayment.AssociateId} for MerchantID: {commissionPayment.MerchantId}");
+                // If desired, a call to the MoneyOutService.SetActiveOnFileMerchant() could be made here to try to provision the account again.
             }
 
             var payAssociate = await _ewalletService.AddToBalance(accountNumber, commissionPayment.Total);
@@ -74,35 +70,16 @@ namespace ACMEClientExtension.Merchants.Ewallet
             return await Task.FromResult(payAssociate);
         }
 
-        public async override Task ProvisionAccount(int associateId)
+        public async override Task<Dictionary<string, string>> ProvisionAccount(int associateId)
         {
-            await ProvisionNewAccount(associateId, MerchantId, _merchantName);
-        }
+            string accountNumber = await CreateAssociateAccount(associateId);
 
-        private async Task<string> ProvisionNewAccount(int associateId, int merchantId, string merchantName)
-        {
-            var onFileMerchants = await _moneyOutService.GetOnFileMerchants(associateId);
-            bool alreadyProvisioned = onFileMerchants.FirstOrDefault(x => x.MerchantId == merchantId)?.CustomValues?.ContainsKey(AccountNumber) ?? false;
-
-            string accountNumber = "";
-            if (!alreadyProvisioned)
+            var associateCustomValues = new Dictionary<string, string>()
             {
-                accountNumber = await CreateAssociateAccount(associateId);
-                var accountInfo = new OnFileMerchant()
-                {
-                    AssociateId = associateId,
-                    CustomValues = new Dictionary<string, string>()
-                    {
-                        { AccountNumber, accountNumber }
-                    },
-                    MerchantId = merchantId,
-                    MerchantName = merchantName
-                };
+                { AccountNumber, accountNumber }
+            };
 
-                await _moneyOutService.SetActiveOnFileMerchant(accountInfo);
-            }
-
-            return await Task.FromResult(accountNumber);
+            return await Task.FromResult(associateCustomValues);
         }
 
         private async Task<string> CreateAssociateAccount(int associateId)

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyOut.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyOut.cs
@@ -1,0 +1,116 @@
+﻿using ACMEClientExtension.Merchants.Ewallet.Interfaces;
+using DirectScale.Disco.Extension;
+using DirectScale.Disco.Extension.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ACMEClientExtension.Merchants.Ewallet
+{
+    public class EWalletMoneyOut : CommissionMerchant
+    {
+        public const int MerchantId = 9101;
+        private const string _merchantName = "MyCommissionMerchant";
+
+
+        public const string AccountNumber = "AccountNumber";
+        public IMoneyOutService _moneyOutService { get; set; }
+        public IEwalletService _ewalletService { get; set; }
+        private readonly IAssociateService _associateService;
+        public EWalletMoneyOut(IMoneyOutService moneyOutService, IEwalletService ewalletService, IAssociateService associateService)
+        {
+            _moneyOutService = moneyOutService ?? throw new ArgumentNullException(nameof(moneyOutService));
+            _ewalletService = ewalletService ?? throw new ArgumentNullException(nameof(ewalletService));
+            _associateService = associateService ?? throw new ArgumentNullException(nameof(associateService));
+        }
+
+        public async override Task<CommissionPaymentResult[]> PayCommissions(int batchId, CommissionPayment[] payments)
+        {
+            var commissionPaymentResults = new CommissionPaymentResult[payments.Length];
+
+            for (int i = 0; i < payments.Length; i++)
+            {
+                commissionPaymentResults[i] = new CommissionPaymentResult()
+                {
+                    DatePaid = DateTime.UtcNow,
+                    Status = CommissionPaymentStatus.Submitted,
+                    PaymentUniqueId = payments[i].PaymentUniqueId,
+                };
+
+                Models.TransactionStatus payAssociateResult = Models.TransactionStatus.Failed;
+                try
+                {
+                    payAssociateResult = await PayAssociate(payments[i]);
+                }
+                catch (Exception) // do not let external calls stop the loop because some may have processed successfully.
+                {
+                    commissionPaymentResults[i].Status = CommissionPaymentStatus.Failed;
+                    commissionPaymentResults[i].TransactionNumber = "transaction number from external system if applicable";
+                    commissionPaymentResults[i].ErrorMessage = "Error message from external payment vendor";
+                }
+
+                if (payAssociateResult == Models.TransactionStatus.Success)
+                {
+                    commissionPaymentResults[i].TransactionNumber = "transaction number from external system";
+                    commissionPaymentResults[i].Status = CommissionPaymentStatus.Paid;
+                }
+            }
+
+            return await Task.FromResult(commissionPaymentResults);
+        }
+
+        private async Task<Models.TransactionStatus> PayAssociate(CommissionPayment commissionPayment)
+        {
+            string accountNumber = "";
+            bool accountProvisioned = commissionPayment.MerchantCustomFields.TryGetValue(AccountNumber, out accountNumber);
+            if (!accountProvisioned)
+            {
+                accountNumber = await ProvisionNewAccount(commissionPayment.AssociateId, commissionPayment.MerchantId, _merchantName);
+            }
+
+            var payAssociate = await _ewalletService.AddToBalance(accountNumber, commissionPayment.Amount);
+
+            return await Task.FromResult(payAssociate);
+        }
+
+        public async override Task ProvisionAccount(int associateId)
+        {
+            await ProvisionNewAccount(associateId, MerchantId, _merchantName);
+        }
+
+        private async Task<string> ProvisionNewAccount(int associateId, int merchantId, string merchantName)
+        {
+            var onFileMerchants = await _moneyOutService.GetOnFileMerchants(associateId);
+            bool alreadyProvisioned = onFileMerchants.FirstOrDefault(x => x.MerchantId == merchantId)?.CustomValues?.ContainsKey(AccountNumber) ?? false;
+
+            string accountNumber = "";
+            if (!alreadyProvisioned)
+            {
+                accountNumber = await CreateAssociateAccount(associateId);
+                var accountInfo = new OnFileMerchant()
+                {
+                    AssociateId = associateId,
+                    CustomValues = new Dictionary<string, string>()
+                    {
+                        { AccountNumber, accountNumber }
+                    },
+                    MerchantId = merchantId,
+                    MerchantName = merchantName
+                };
+
+                await _moneyOutService.SetActiveOnFileMerchant(accountInfo);
+            }
+
+            return await Task.FromResult(accountNumber);
+        }
+
+        private async Task<string> CreateAssociateAccount(int associateId)
+        {
+            Associate associate = await _associateService.GetAssociate(associateId);
+
+            return await _ewalletService.ProvisionAccount(associateId, associate.DisplayFirstName, associate.DisplayLastName, associate.EmailAddress);
+        }
+
+    }
+}

--- a/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyOut.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EWalletMoneyOut.cs
@@ -69,7 +69,7 @@ namespace ACMEClientExtension.Merchants.Ewallet
                 accountNumber = await ProvisionNewAccount(commissionPayment.AssociateId, commissionPayment.MerchantId, _merchantName);
             }
 
-            var payAssociate = await _ewalletService.AddToBalance(accountNumber, commissionPayment.Amount);
+            var payAssociate = await _ewalletService.AddToBalance(accountNumber, commissionPayment.Total);
 
             return await Task.FromResult(payAssociate);
         }

--- a/ACMEClientExtension/Merchants/Ewallet/EwalletService.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EwalletService.cs
@@ -1,0 +1,101 @@
+﻿using ACMEClientExtension.Merchants.Ewallet.Interfaces;
+using DirectScale.Disco.Extension;
+using DirectScale.Disco.Extension.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ACMEClientExtension.Merchants.Ewallet
+{
+    public class EwalletService : IEwalletService
+    {
+        public IAssociateService _associateService { get; set; }
+        public EwalletService(IAssociateService associateService)
+        {
+            _associateService = associateService ?? throw new ArgumentNullException(nameof(associateService));
+        }
+
+        public async Task<Models.TransactionStatus> AddToBalance(string payorId, decimal amount)
+        {
+            var associateId = await DecodeAssociateIdFromPayorId(payorId);
+            Associate associate = await _associateService.GetAssociate(associateId);
+
+            decimal currentBalance;
+
+            if (associate.AssociateCustom.Field2 == null)
+            {
+                currentBalance = 0m;
+            }
+            else if (decimal.TryParse(associate.AssociateCustom.Field2, out currentBalance) == false)
+            {
+                throw new Exception("An error occured because the current balance of the account cannot be determined.");
+            }
+
+            var newBalance = currentBalance + amount;
+            associate.AssociateCustom.Field2 = newBalance.ToString();
+
+            await _associateService.UpdateAssociate(associate);
+
+            return Models.TransactionStatus.Success;
+        }
+
+        public async Task<string> ProvisionAccount(int associateId, string firstName, string lastName, string email)
+        {
+            Associate associate = await _associateService.GetAssociate(associateId);
+
+            if (associate.AssociateCustom.Field1 == null)
+            {
+                associate.AssociateCustom.Field1 = await EncodeAssociateId(associateId);
+
+                await _associateService.UpdateAssociate(associate);
+            }
+
+            return associate.AssociateCustom.Field1;
+        }
+
+        private async Task<string> EncodeAssociateId(int associateId)
+        {
+            return await Task.FromResult($"wal_{(associateId * 239) / 19}");
+        }
+
+        private async Task<int> DecodeAssociateIdFromPayorId(string payorId)
+        {
+            if (int.TryParse(payorId.Substring(4), out int encodedAssociateId))
+            {
+                return await Task.FromResult((encodedAssociateId * 19) / 239);
+            }
+
+            throw new Exception("An Error Occured");
+        }
+
+        public async Task<Models.TransactionStatus> RemoveFromBalance(string payorId, decimal amount)
+        {
+            var associateId = await DecodeAssociateIdFromPayorId(payorId);
+            Associate associate = await _associateService.GetAssociate(associateId);
+
+            decimal currentBalance;
+
+            if (associate.AssociateCustom.Field2 == null)
+            {
+                currentBalance = 0m;
+            }
+            else if (decimal.TryParse(associate.AssociateCustom.Field2, out currentBalance) == false)
+            {
+                throw new Exception("An error occured because the current balance of the account cannot be determined.");
+            }
+
+            if (Math.Round(amount, 2) > Math.Round(amount, 2))
+            {
+                return Models.TransactionStatus.InsufficientFunds;
+            }
+
+            var newBalance = currentBalance - amount;
+            associate.AssociateCustom.Field2 = newBalance.ToString();
+
+            await _associateService.UpdateAssociate(associate);
+
+            return Models.TransactionStatus.Success;
+        }
+    }
+}

--- a/ACMEClientExtension/Merchants/Ewallet/EwalletService.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/EwalletService.cs
@@ -23,7 +23,11 @@ namespace ACMEClientExtension.Merchants.Ewallet
 
             decimal currentBalance;
 
-            if (associate.AssociateCustom.Field2 == null)
+            if (associate.AssociateCustom == null)
+            {
+                associate.AssociateCustom = new AssociateCustomFields();
+            }
+            if (string.IsNullOrWhiteSpace(associate.AssociateCustom.Field2))
             {
                 currentBalance = 0m;
             }
@@ -44,6 +48,10 @@ namespace ACMEClientExtension.Merchants.Ewallet
         {
             Associate associate = await _associateService.GetAssociate(associateId);
 
+            if (associate.AssociateCustom == null)
+            {
+                associate.AssociateCustom = new AssociateCustomFields();
+            }
             if (associate.AssociateCustom.Field1 == null)
             {
                 associate.AssociateCustom.Field1 = await EncodeAssociateId(associateId);
@@ -56,14 +64,14 @@ namespace ACMEClientExtension.Merchants.Ewallet
 
         private async Task<string> EncodeAssociateId(int associateId)
         {
-            return await Task.FromResult($"wal_{(associateId * 239) / 19}");
+            return await Task.FromResult($"wal_{associateId + 12391893}");
         }
 
         private async Task<int> DecodeAssociateIdFromPayorId(string payorId)
         {
             if (int.TryParse(payorId.Substring(4), out int encodedAssociateId))
             {
-                return await Task.FromResult((encodedAssociateId * 19) / 239);
+                return await Task.FromResult(encodedAssociateId - 12391893);
             }
 
             throw new Exception("An Error Occured");
@@ -85,7 +93,7 @@ namespace ACMEClientExtension.Merchants.Ewallet
                 throw new Exception("An error occured because the current balance of the account cannot be determined.");
             }
 
-            if (Math.Round(amount, 2) > Math.Round(amount, 2))
+            if (Math.Round(amount, 2) > Math.Round(currentBalance, 2))
             {
                 return Models.TransactionStatus.InsufficientFunds;
             }

--- a/ACMEClientExtension/Merchants/Ewallet/Interfaces/IEwalletService.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/Interfaces/IEwalletService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ACMEClientExtension.Merchants.Ewallet.Interfaces
+{
+    public interface IEwalletService
+    {
+        Task<string> ProvisionAccount(int associateId, string firstName, string lastName, string email);
+        Task<Models.TransactionStatus> AddToBalance(string payorId, decimal amount);
+        Task<Models.TransactionStatus> RemoveFromBalance(string payorId, decimal amount);
+    }
+}

--- a/ACMEClientExtension/Merchants/Ewallet/Models/TransactionStatus.cs
+++ b/ACMEClientExtension/Merchants/Ewallet/Models/TransactionStatus.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ACMEClientExtension.Merchants.Ewallet.Models
+{
+    public enum TransactionStatus
+    {
+        Success,
+        InsufficientFunds,
+        Failed
+    }
+}

--- a/ACMEClientExtension/Startup.cs
+++ b/ACMEClientExtension/Startup.cs
@@ -12,6 +12,7 @@ using DirectScale.Disco.Extension.Middleware;
 using DirectScale.Disco.Extension.Middleware.Models;
 using ACMEClientExtension.Hooks.Autoships;
 using ACMEClientExtension.Hooks.Orders;
+using ACMEClientExtension.Merchants.Ewallet;
 
 namespace ACMEClientExtension
 {
@@ -51,6 +52,9 @@ namespace ACMEClientExtension
 
                 // WebHooks
                 options.AddEventHandler("OrderCreated", "/api/webhooks/Order/CreateOrder");
+
+                options.AddMerchant<EWalletMoneyIn>(9100, "Ewallet Money In USD", "test", "USD");
+                options.AddMerchant<EWalletMoneyOut>(9101, "Ewallet Money Out USD", "test", "USD");
             });
 
             services.Configure<IISServerOptions>(options =>

--- a/ACMEClientExtension/Startup.cs
+++ b/ACMEClientExtension/Startup.cs
@@ -13,6 +13,7 @@ using DirectScale.Disco.Extension.Middleware.Models;
 using ACMEClientExtension.Hooks.Autoships;
 using ACMEClientExtension.Hooks.Orders;
 using ACMEClientExtension.Merchants.Ewallet;
+using ACMEClientExtension.Merchants.Ewallet.Interfaces;
 
 namespace ACMEClientExtension
 {
@@ -29,6 +30,7 @@ namespace ACMEClientExtension
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
+            services.AddSingleton<IEwalletService, EwalletService>();
 
             services.AddDirectScale(options =>
             {

--- a/ACMEClientExtension/Startup.cs
+++ b/ACMEClientExtension/Startup.cs
@@ -65,7 +65,6 @@ namespace ACMEClientExtension
                 options.AddMerchant<StripeMoneyInMerchantUsd>(9002, "Stripe Custom", "An example merchant", "USD");
                 options.AddMerchant<StripeMoneyInMerchantJpy>(9003, "Stripe Custom", "An example merchant", "JPY");
                 options.AddMerchant<MyCommissionMerchant>(9001, "MyCommissionMerchant", "An Example Commission Merchant", "USD");
-
                 options.AddMerchant<EWalletMoneyIn>(9100, "Ewallet Money In USD", "test", "USD");
                 options.AddMerchant<EWalletMoneyOut>(9101, "Ewallet Money Out USD", "test", "USD");
             });


### PR DESCRIPTION
This solution uses 2 **Associate Custom Fields** to generate and save a PayerID and track the balance of the EWallet. Commission Payouts increase the balance and any balance can be used to pay for orders. This is accomplished by implementing a CommissionMerchant and a SinglePaymentMoneyInMerchant. This implementation should only be used as an example to understand how to write an integration with a third-party EWallet solution. All third-party integrations should be rigorously tested to ensure no defects since miscalculations could be costly.